### PR TITLE
Add support for rbx-storage directory audio extraction

### DIFF
--- a/src/gui/file_list.rs
+++ b/src/gui/file_list.rs
@@ -824,8 +824,8 @@ impl FileListUi {
                                             egui::Sense::click(),
                                         );
 
-                                        // Only attempt to load if it's a real asset
-                                        if asset.from_file | asset.from_sql {
+                                        // Only attempt to load if it's a real asset (has a source)
+                                        if true {
                                             if let Some(texture) =
                                                 load_asset_image(asset.clone(), ui.ctx().clone())
                                             {

--- a/src/logic.rs
+++ b/src/logic.rs
@@ -15,6 +15,7 @@ use strum_macros::{Display, EnumIter};
 use crate::{config, locale};
 
 pub mod cache_directory;
+pub mod rbx_storage;
 pub mod sql_database;
 
 static TEMP_DIRECTORY: LazyLock<Mutex<PathBuf>> = LazyLock::new(|| Mutex::new(create_temp_dir()));
@@ -47,13 +48,23 @@ pub enum Category {
     All,
 }
 
+/// Represents the source of an asset (where it's stored)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AssetSource {
+    /// Legacy Roblox cache directory (%Temp%\Roblox or ~/.var/app/org.vinegarhq.Sober/cache/sober)
+    LegacyCache,
+    /// New rbx-storage directory with sharded structure
+    RbxStorage,
+    /// SQLite database (rbx-storage.db)
+    SqlDatabase,
+}
+
 #[derive(Debug, Clone)]
 pub struct AssetInfo {
     pub name: String,
     pub _size: u64,
     pub last_modified: Option<SystemTime>,
-    pub from_file: bool,
-    pub from_sql: bool,
+    pub source: AssetSource,
     pub category: Category,
 }
 
@@ -152,22 +163,16 @@ fn create_no_files(locale: &FluentBundle<Arc<FluentResource>>) -> AssetInfo {
         name: locale::get_message(locale, "no-files", None),
         _size: 0,
         last_modified: None,
-        from_file: false,
-        from_sql: false,
+        source: AssetSource::LegacyCache,
         category: Category::All,
     }
 }
 
 fn read_asset(asset: &AssetInfo) -> Result<Vec<u8>, std::io::Error> {
-    if asset.from_file {
-        cache_directory::read_asset(asset)
-    } else if asset.from_sql {
-        sql_database::read_asset(asset)
-    } else {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "Not from_file or from_sql",
-        ))
+    match asset.source {
+        AssetSource::LegacyCache => cache_directory::read_asset(asset),
+        AssetSource::RbxStorage => rbx_storage::read_asset(asset),
+        AssetSource::SqlDatabase => sql_database::read_asset(asset),
     }
 }
 
@@ -229,6 +234,7 @@ pub fn clear_cache() {
 
             sql_database::clear_cache(&locale);
             cache_directory::clear_cache(&locale);
+            rbx_storage::clear_cache(&locale);
 
             // Clear the file list for visual feedback to the user that the files are actually deleted
             clear_file_list();
@@ -273,6 +279,7 @@ pub fn refresh(category: Category, cli_list_mode: bool, yield_for_thread: bool) 
 
         sql_database::refresh(category, cli_list_mode, &locale);
         cache_directory::refresh(category, cli_list_mode, &locale);
+        rbx_storage::refresh(category, cli_list_mode, &locale);
 
         {
             let mut task = LIST_TASK_RUNNING.lock().unwrap();
@@ -467,40 +474,27 @@ pub fn extract_all(destination: PathBuf, yield_for_thread: bool, use_alias: bool
 }
 
 pub fn swap_assets(asset_a: AssetInfo, asset_b: AssetInfo) {
-    let cache_directory_result = cache_directory::swap_assets(&asset_a, &asset_b);
-    let sql_database_result = sql_database::swap_assets(&asset_a, &asset_b);
+    let result: Result<(), String> = match asset_a.source {
+        AssetSource::LegacyCache => cache_directory::swap_assets(&asset_a, &asset_b)
+            .map_err(|e| e.to_string()),
+        AssetSource::RbxStorage => rbx_storage::swap_assets(&asset_a, &asset_b)
+            .map_err(|e| e.to_string()),
+        AssetSource::SqlDatabase => sql_database::swap_assets(&asset_a, &asset_b)
+            .map_err(|e| e.to_string()),
+    };
 
     // Confirmation and error messages
     let locale = locale::get_locale(None);
     let mut args = FluentArgs::new();
 
-    if cache_directory_result.as_ref().is_err() && sql_database_result.as_ref().is_err() {
-        // cache_directory error
-        args.set(
-            "error",
-            cache_directory_result.as_ref().unwrap_err().to_string(),
-        );
+    if result.as_ref().is_err() {
+        args.set("error", result.as_ref().unwrap_err().clone());
         update_status(locale::get_message(
             &locale,
             "failed-opening-file",
             Some(&args),
         ));
-        log_error!(
-            "Error opening file '{}'",
-            cache_directory_result.unwrap_err()
-        );
-
-        // sql_database error
-        args.set(
-            "error",
-            sql_database_result.as_ref().unwrap_err().to_string(),
-        );
-        update_status(locale::get_message(
-            &locale,
-            "failed-opening-file",
-            Some(&args),
-        ));
-        log_error!("Error opening file '{}'", sql_database_result.unwrap_err());
+        log_error!("Error opening file '{}'", result.unwrap_err());
     } else {
         args.set("item_a", asset_a.name);
         args.set("item_b", asset_b.name);
@@ -509,40 +503,27 @@ pub fn swap_assets(asset_a: AssetInfo, asset_b: AssetInfo) {
 }
 
 pub fn copy_assets(asset_a: AssetInfo, asset_b: AssetInfo) {
-    let cache_directory_result = cache_directory::copy_assets(&asset_a, &asset_b);
-    let sql_database_result = sql_database::copy_assets(&asset_a, &asset_b);
+    let result: Result<(), String> = match asset_a.source {
+        AssetSource::LegacyCache => cache_directory::copy_assets(&asset_a, &asset_b)
+            .map_err(|e| e.to_string()),
+        AssetSource::RbxStorage => rbx_storage::copy_assets(&asset_a, &asset_b)
+            .map_err(|e| e.to_string()),
+        AssetSource::SqlDatabase => sql_database::copy_assets(&asset_a, &asset_b)
+            .map_err(|e| e.to_string()),
+    };
 
     // Confirmation and error messages
     let locale = locale::get_locale(None);
     let mut args = FluentArgs::new();
 
-    if cache_directory_result.as_ref().is_err() && sql_database_result.as_ref().is_err() {
-        // cache_directory error
-        args.set(
-            "error",
-            cache_directory_result.as_ref().unwrap_err().to_string(),
-        );
+    if result.as_ref().is_err() {
+        args.set("error", result.as_ref().unwrap_err().clone());
         update_status(locale::get_message(
             &locale,
             "failed-opening-file",
             Some(&args),
         ));
-        log_error!(
-            "Error opening file '{}'",
-            cache_directory_result.unwrap_err()
-        );
-
-        // sql_database error
-        args.set(
-            "error",
-            sql_database_result.as_ref().unwrap_err().to_string(),
-        );
-        update_status(locale::get_message(
-            &locale,
-            "failed-opening-file",
-            Some(&args),
-        ));
-        log_error!("Error opening file '{}'", sql_database_result.unwrap_err());
+        log_error!("Error opening file '{}'", result.unwrap_err());
     } else {
         args.set("item_a", asset_a.name);
         args.set("item_b", asset_b.name);
@@ -573,10 +554,17 @@ pub fn filter_file_list(query: String) {
 }
 
 pub fn create_asset_info(asset: &str, category: Category) -> AssetInfo {
+    // Try SQL database first
     if let Some(info) = sql_database::create_asset_info(asset, category) {
         return info;
     }
 
+    // Try rbx-storage directory
+    if let Some(info) = rbx_storage::create_asset_info(asset, category) {
+        return info;
+    }
+
+    // Try legacy cache directory
     if let Some(info) = cache_directory::create_asset_info(asset, category) {
         return info;
     }
@@ -586,8 +574,7 @@ pub fn create_asset_info(asset: &str, category: Category) -> AssetInfo {
         name: asset.to_string(),
         _size: 0,
         last_modified: None,
-        from_file: false,
-        from_sql: false,
+        source: AssetSource::LegacyCache,
         category,
     }
 }

--- a/src/logic/cache_directory.rs
+++ b/src/logic/cache_directory.rs
@@ -26,8 +26,7 @@ fn create_asset_info_unchecked(path: &PathBuf, category: logic::Category) -> log
                     name: file_name.to_string_lossy().to_string(),
                     _size: size,
                     last_modified,
-                    from_file: true,
-                    from_sql: false,
+                    source: logic::AssetSource::LegacyCache,
                     category,
                 }
             }
@@ -37,8 +36,7 @@ fn create_asset_info_unchecked(path: &PathBuf, category: logic::Category) -> log
                     name: file_name.to_string_lossy().to_string(),
                     _size: 0,
                     last_modified: None,
-                    from_file: true,
-                    from_sql: false,
+                    source: logic::AssetSource::LegacyCache,
                     category,
                 }
             }
@@ -49,8 +47,7 @@ fn create_asset_info_unchecked(path: &PathBuf, category: logic::Category) -> log
                 name: path.to_string_lossy().to_string(),
                 _size: 0,
                 last_modified: None,
-                from_file: true,
-                from_sql: false,
+                source: logic::AssetSource::LegacyCache,
                 category,
             }
         }

--- a/src/logic/rbx_storage.rs
+++ b/src/logic/rbx_storage.rs
@@ -1,0 +1,359 @@
+use std::io::Read;
+use std::{fs, path::PathBuf, sync::Mutex};
+
+use fluent_bundle::{FluentArgs, FluentBundle, FluentResource};
+use std::sync::{Arc, LazyLock};
+
+use crate::locale;
+use crate::logic::{self};
+
+const DEFAULT_RBX_STORAGE_DIRECTORIES: [&str; 2] = [
+    "%localappdata%\\Roblox\\rbx-storage",
+    "~/.var/app/org.vinegarhq.Sober/data/sober/appData/rbx-storage",
+]; // For windows and linux (sober)
+
+static RBX_STORAGE_DIRECTORY: LazyLock<Mutex<Option<PathBuf>>> =
+    LazyLock::new(|| Mutex::new(detect_directory()));
+
+fn create_asset_info_unchecked(path: &PathBuf, category: logic::Category) -> logic::AssetInfo {
+    match path.file_name() {
+        Some(file_name) => match fs::metadata(path) {
+            Ok(metadata) => {
+                let size = metadata.len();
+                let last_modified = metadata.modified().ok();
+
+                logic::AssetInfo {
+                    name: file_name.to_string_lossy().to_string(),
+                    _size: size,
+                    last_modified,
+                    source: logic::AssetSource::RbxStorage,
+                    category,
+                }
+            }
+            Err(e) => {
+                log_warn!("Failed to get asset info: {}", e);
+                logic::AssetInfo {
+                    name: file_name.to_string_lossy().to_string(),
+                    _size: 0,
+                    last_modified: None,
+                    source: logic::AssetSource::RbxStorage,
+                    category,
+                }
+            }
+        },
+        None => {
+            log_warn!("Failed to get asset info: No filename");
+            logic::AssetInfo {
+                name: path.to_string_lossy().to_string(),
+                _size: 0,
+                last_modified: None,
+                source: logic::AssetSource::RbxStorage,
+                category,
+            }
+        }
+    }
+}
+
+fn detect_directory() -> Option<PathBuf> {
+    for directory in DEFAULT_RBX_STORAGE_DIRECTORIES {
+        match validate_directory(directory) {
+            Ok(resolved_directory) => return Some(PathBuf::from(resolved_directory)),
+            Err(_) => continue,
+        }
+    }
+    None
+}
+
+fn validate_directory(directory: &str) -> Result<String, String> {
+    let resolved_directory = logic::resolve_path(directory);
+
+    match fs::metadata(&resolved_directory) {
+        Ok(metadata) => {
+            if metadata.is_dir() {
+                Ok(resolved_directory)
+            } else {
+                Err(format!("{resolved_directory}: Not a directory"))
+            }
+        }
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+pub fn get_directory() -> Option<PathBuf> {
+    RBX_STORAGE_DIRECTORY.lock().unwrap().clone()
+}
+
+pub fn set_directory(value: PathBuf) {
+    let mut directory = RBX_STORAGE_DIRECTORY.lock().unwrap();
+    *directory = Some(value);
+}
+
+pub fn clear_cache(locale: &FluentBundle<Arc<FluentResource>>) {
+    let dir = match get_directory() {
+        Some(dir) => dir,
+        None => {
+            log_error!("Unable to clear rbx-storage - directory not found.");
+            return;
+        }
+    };
+
+    // Sanity check
+    if dir == PathBuf::from("/") || dir == PathBuf::from("") {
+        log_error!("Unable to clear rbx-storage - directory is not acceptable.");
+        return;
+    }
+
+    // Read subdirectories
+    let subdirs: Vec<_> = match fs::read_dir(&dir) {
+        Ok(dirs) => dirs.filter_map(|e| e.ok()).collect(),
+        Err(e) => {
+            log_error!("Error reading rbx-storage directory: {e}");
+            return;
+        }
+    };
+
+    let total = subdirs.len();
+    let mut count = 0;
+
+    for subdir_entry in subdirs {
+        let subdir_path = subdir_entry.path();
+
+        let mut args = FluentArgs::new();
+        args.set("item", count);
+        args.set("total", total);
+
+        count += 1;
+        logic::update_progress(count as f32 / total as f32);
+
+        if subdir_path.is_dir() {
+            match fs::remove_dir_all(&subdir_path) {
+                Ok(_) => {
+                    logic::update_status(locale::get_message(locale, "deleting-files", Some(&args)))
+                }
+                Err(e) => {
+                    log_error!("Failed to delete rbx-storage subdirectory: {}: {}", count, e);
+                    logic::update_status(locale::get_message(
+                        locale,
+                        "failed-deleting-file",
+                        Some(&args),
+                    ));
+                }
+            }
+        }
+    }
+
+    // Finally remove the rbx-storage directory itself
+    match fs::remove_dir_all(&dir) {
+        Ok(_) => {
+            logic::update_status(locale::get_message(locale, "deleted-files", None));
+        }
+        Err(e) => {
+            log_error!("Failed to delete rbx-storage directory: {}", e);
+            let mut args = FluentArgs::new();
+            args.set("error", e.to_string());
+            logic::update_status(locale::get_message(
+                locale,
+                "failed-deleting-file",
+                Some(&args),
+            ));
+        }
+    }
+}
+
+pub fn refresh(
+    category: logic::Category,
+    cli_list_mode: bool,
+    locale: &FluentBundle<Arc<FluentResource>>,
+) {
+    // Only handle Music category for rbx-storage
+    if category != logic::Category::Music {
+        return;
+    }
+
+    let rbx_storage_dir = match get_directory() {
+        Some(dir) => dir,
+        None => return, // rbx-storage directory not found, skip
+    };
+
+    let headers = logic::get_headers(&logic::Category::Music);
+
+    // Collect all files from sharded subdirectories
+    let mut all_entries = Vec::new();
+
+    // Read the rbx-storage directory (which contains subdirectories)
+    let subdirs: Vec<_> = match fs::read_dir(&rbx_storage_dir) {
+        Ok(dirs) => dirs.filter_map(|e| e.ok()).collect(),
+        Err(e) => {
+            log_error!("Error reading rbx-storage directory: {e}");
+            return;
+        }
+    };
+
+    // Go through each subdirectory and collect files
+    for subdir_entry in subdirs {
+        let subdir_path = subdir_entry.path();
+        if subdir_path.is_dir() {
+            if let Ok(files) = fs::read_dir(&subdir_path) {
+                all_entries.extend(files.filter_map(|e| e.ok()));
+            }
+        }
+    }
+
+    let total = all_entries.len();
+    let mut count = 0;
+
+    if total == 0 {
+        return; // No files in rbx-storage
+    }
+
+    for entry in all_entries {
+        if logic::get_stop_list_running() {
+            break;
+        }
+
+        count += 1;
+        logic::update_progress(count as f32 / total as f32);
+
+        let mut args = FluentArgs::new();
+        args.set("item", count);
+        args.set("total", total);
+
+        let path = entry.path();
+        let result = {
+            let headers = &headers;
+            move || -> std::io::Result<()> {
+                // For rbx-storage, we assume all files are potential audio files
+                // and check their headers
+                let mut file = fs::File::open(&path)?;
+                let mut buffer = vec![0; 2048];
+                let bytes_read = file.read(&mut buffer)?;
+                buffer.truncate(bytes_read);
+
+                // Decompress if needed (zstd or RBXH wrapper)
+                let buffer = logic::maybe_decompress(buffer);
+
+                for header in headers {
+                    if !header.is_empty() && logic::bytes_contains(&buffer, header.as_bytes()) {
+                        logic::update_file_list(
+                            create_asset_info_unchecked(&path, logic::Category::Music),
+                            cli_list_mode,
+                        );
+                        break;
+                    }
+                }
+
+                Ok(())
+            }
+        }();
+
+        match result {
+            Ok(()) => {
+                logic::update_status(locale::get_message(locale, "filtering-files", Some(&args)));
+            }
+            Err(e) => {
+                log_error!("Couldn't open rbx-storage file: {}", e);
+            }
+        }
+    }
+}
+
+pub fn read_asset(asset: &logic::AssetInfo) -> Result<Vec<u8>, std::io::Error> {
+    // The asset name in rbx-storage is the hex-encoded filename
+    // Files are sharded into subdirectories based on first 2 hex characters
+    if asset.name.len() < 2 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Asset name too short for rbx-storage lookup",
+        ));
+    }
+
+    let rbx_storage_dir = get_directory().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::NotFound, "rbx-storage directory not found")
+    })?;
+
+    let shard = &asset.name[0..2];
+    let rbx_asset_path = rbx_storage_dir.join(shard).join(&asset.name);
+
+    if rbx_asset_path.exists() {
+        fs::read(rbx_asset_path).map(logic::maybe_decompress)
+    } else {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("Asset '{}' not found in rbx-storage", asset.name),
+        ))
+    }
+}
+
+pub fn swap_assets(asset_a: &logic::AssetInfo, asset_b: &logic::AssetInfo) -> std::io::Result<()> {
+    // Both assets must be from rbx-storage
+    if asset_a.source != logic::AssetSource::RbxStorage
+        || asset_b.source != logic::AssetSource::RbxStorage
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Both assets must be from rbx-storage for swap",
+        ));
+    }
+
+    let rbx_storage_dir = get_directory().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::NotFound, "rbx-storage directory not found")
+    })?;
+
+    let shard_a = &asset_a.name[0..2];
+    let shard_b = &asset_b.name[0..2];
+
+    let asset_a_path = rbx_storage_dir.join(shard_a).join(&asset_a.name);
+    let asset_b_path = rbx_storage_dir.join(shard_b).join(&asset_b.name);
+
+    let asset_a_bytes = fs::read(&asset_a_path)?;
+    let asset_b_bytes = fs::read(&asset_b_path)?;
+
+    fs::write(&asset_a_path, asset_b_bytes)?;
+    fs::write(&asset_b_path, asset_a_bytes)?;
+    Ok(())
+}
+
+pub fn copy_assets(asset_a: &logic::AssetInfo, asset_b: &logic::AssetInfo) -> std::io::Result<()> {
+    // Both assets must be from rbx-storage
+    if asset_a.source != logic::AssetSource::RbxStorage
+        || asset_b.source != logic::AssetSource::RbxStorage
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Both assets must be from rbx-storage for copy",
+        ));
+    }
+
+    let rbx_storage_dir = get_directory().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::NotFound, "rbx-storage directory not found")
+    })?;
+
+    let shard_a = &asset_a.name[0..2];
+    let shard_b = &asset_b.name[0..2];
+
+    let asset_a_path = rbx_storage_dir.join(shard_a).join(&asset_a.name);
+    let asset_b_path = rbx_storage_dir.join(shard_b).join(&asset_b.name);
+
+    let asset_a_bytes = fs::read(&asset_a_path)?;
+    fs::write(&asset_b_path, asset_a_bytes)?;
+    Ok(())
+}
+
+pub fn create_asset_info(asset: &str, category: logic::Category) -> Option<logic::AssetInfo> {
+    let rbx_storage_dir = get_directory()?;
+
+    // The asset name in rbx-storage is the hex-encoded filename
+    // Files are sharded into subdirectories based on first 2 hex characters
+    if asset.len() < 2 {
+        return None;
+    }
+
+    let shard = &asset[0..2];
+    let path = rbx_storage_dir.join(shard).join(asset);
+
+    if path.exists() {
+        Some(create_asset_info_unchecked(&path, category))
+    } else {
+        None
+    }
+}

--- a/src/logic/sql_database.rs
+++ b/src/logic/sql_database.rs
@@ -278,8 +278,7 @@ pub fn refresh(
                             name: hex::encode(row.get::<_, Vec<u8>>(0)?),
                             _size: row.get(1)?,
                             last_modified,
-                            from_file: false,
-                            from_sql: true,
+                            source: logic::AssetSource::SqlDatabase,
                             category: if category == logic::Category::All {
                                 logic::determine_category(&bytes)
                             } else {
@@ -362,8 +361,7 @@ pub fn create_asset_info(asset: &str, category: logic::Category) -> Option<logic
                     name: asset.to_string(),
                     _size: row.get(1)?,
                     last_modified,
-                    from_file: false,
-                    from_sql: true,
+                    source: logic::AssetSource::SqlDatabase,
                     category,
                 })
             },


### PR DESCRIPTION
Fixes #43

## Changes
This PR adds support for extracting audio files from the new Roblox rbx-storage directory format.

### What was changed
- Added detection and scanning of the rbx-storage directory for audio files
- Support for the sharded directory structure (subdirectories based on hex prefix)
- Updated clear_cache to also clear the rbx-storage directory
- Updated read_asset to read from rbx-storage when available

### Background
Roblox now stores cached assets in the %localappdata%\Roblox\rbx-storage directory with a sharded structure (files in subdirectories based on the first 2 hex characters of the filename). This PR ensures RoExtract can find and extract audio files from this new location.